### PR TITLE
Add settings panel, markdown rendering, and summarization

### DIFF
--- a/netlify/functions/summarize.ts
+++ b/netlify/functions/summarize.ts
@@ -1,0 +1,47 @@
+import type { Handler } from '@netlify/functions';
+
+const API_URL = 'https://api.mistral.ai/v1/chat/completions';
+const SUMMARIZER_MODEL = 'mistral-small-latest';
+
+const SYSTEM = `You are a concise conversation summarizer.
+Summarize the prior turns faithfully. Keep facts and decisions. Omit fluff.
+Return a single paragraph (5–10 sentences).`;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
+  const key = process.env.MISTRAL_API_KEY;
+  if (!key) return { statusCode: 500, body: 'Server missing MISTRAL_API_KEY' };
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const { transcript = '' } = body;
+    if (!transcript || typeof transcript !== 'string') {
+      return { statusCode: 400, body: 'transcript (string) required' };
+    }
+
+    const payload = {
+      model: SUMMARIZER_MODEL,
+      messages: [
+        { role: 'system', content: SYSTEM },
+        { role: 'user', content: transcript }
+      ],
+      temperature: 0.2,
+      max_tokens: 600
+    };
+
+    const resp = await fetch(API_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    const txt = await resp.text();
+    if (!resp.ok) return { statusCode: resp.status, body: txt };
+    const data = JSON.parse(txt);
+    const content = data?.choices?.[0]?.message?.content ?? '';
+
+    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ summary: content }) };
+  } catch (e: any) {
+    return { statusCode: 500, body: String(e?.message || e) };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.42.0",
+    "dompurify": "^3.0.9",
+    "marked": "^12.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,348 +1,242 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import type { Message } from '../lib/types';
+import type { Conversation, Message, SettingsRow } from '../lib/types';
 import MessageItem from './MessageItem';
 import Composer from './Composer';
+import Settings from './Settings';
 
-/** Simple helper to timestamp console logs */
 const ts = () => new Date().toISOString();
+const SUMMARIZE_AFTER = 20;   // when total rows exceed this, we start summarizing
+const KEEP_RECENT = 10;       // keep this many most recent rows verbatim when summarizing
 
-/** Writes to console + returns the same message for chaining */
-function log(...args: any[]) {
-  console.log(`[${ts()}]`, ...args);
-}
+function log(...args: any[]) { console.log(`[${ts()}]`, ...args); }
+function logError(label: string, err: any) { console.error(`[${ts()}] ${label}:`, err); }
 
-/** Writes errors to console.error */
-function logError(label: string, err: any) {
-  console.error(`[${ts()}] ${label}:`, err);
-}
-
-async function ensureConversation(): Promise<{ id: string } | null> {
+async function ensureConversation(): Promise<Conversation | null> {
   try {
-    const { data: auth } = await supabase.auth.getUser();
-    if (!auth?.user) {
-      log('ensureConversation: no user yet (not signed in?)');
-      return null;
-    }
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
 
-    // Most-recent conversation
-    const { data: convs, error: convErr } = await supabase
-      .from('conversations')
-      .select('*')
-      .order('created_at', { ascending: false })
-      .limit(1);
+    const { data: convs, error } = await supabase.from('conversations')
+      .select('*').order('created_at', { ascending: false }).limit(1);
+    if (error) { logError('ensureConversation select', error); return null; }
 
-    if (convErr) {
-      logError('ensureConversation: select conversations failed', convErr);
-      return null;
-    }
-
-    let conv = convs?.[0];
+    let conv = convs?.[0] as Conversation | undefined;
     if (!conv) {
-      log('ensureConversation: creating new conversation…');
-      const { data: ins, error: insErr } = await supabase
-        .from('conversations')
-        .insert({ user_id: auth.user.id })
-        .select('*')
-        .single();
+      const { data: ins, error: e1 } = await supabase
+        .from('conversations').insert({ user_id: user.id }).select('*').single();
+      if (e1 || !ins) { logError('ensureConversation insert', e1); return null; }
+      conv = ins as Conversation;
 
-      if (insErr || !ins) {
-        logError('ensureConversation: insert conversation failed', insErr);
-        return null;
-      }
-      conv = ins;
-
-      // Seed a system prompt as the first row
-      const system = 'You are a helpful assistant.';
       const { error: seedErr } = await supabase.from('messages').insert({
-        conversation_id: conv.id,
-        role: 'system',
-        content: system,
-        idx: 0,
+        conversation_id: conv.id, role: 'system', content: 'You are a helpful assistant.', idx: 0
       });
-      if (seedErr) {
-        logError('ensureConversation: seeding system message failed', seedErr);
-      }
+      if (seedErr) logError('seed system', seedErr);
     }
-
-    return { id: conv.id as string };
-  } catch (e) {
-    logError('ensureConversation: unexpected', e);
-    return null;
-  }
+    return conv!;
+  } catch (e) { logError('ensureConversation unexpected', e); return null; }
 }
 
-/** Full reload of a conversation’s messages ordered by idx */
-async function fetchMessages(conversationId: string): Promise<Message[]> {
-  const { data, error } = await supabase
-    .from('messages')
-    .select('*')
-    .eq('conversation_id', conversationId)
-    .order('idx');
-
-  if (error) {
-    logError('fetchMessages failed', error);
-    return [];
-  }
+async function fetchMessages(conversation_id: string): Promise<Message[]> {
+  const { data, error } = await supabase.from('messages')
+    .select('*').eq('conversation_id', conversation_id).order('idx');
+  if (error) { logError('fetchMessages', error); return []; }
   return (data as Message[]) || [];
 }
 
-/** Calls Netlify function and returns { content } or throws */
-async function callAssistant(messages: { role: string; content: string }[]) {
-  log('callAssistant: POST /api/chat payload', messages);
-  const resp = await fetch('/api/chat', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages }),
-  });
-
-  const text = await resp.text();
-  if (!resp.ok) {
-    logError(`callAssistant: HTTP ${resp.status}`, text);
-    throw new Error(`HTTP ${resp.status}: ${text.slice(0, 500)}`);
-  }
-
-  try {
-    const data = JSON.parse(text);
-    log('callAssistant: success, usage', data?.usage);
-    return { content: data?.content ?? '' };
-  } catch (e) {
-    logError('callAssistant: JSON parse error', { textSnippet: text.slice(0, 500) });
-    throw e;
-  }
+async function loadSettings(): Promise<Partial<SettingsRow>> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return {};
+  const { data } = await supabase.from('settings').select('*').eq('user_id', user.id).maybeSingle();
+  return (data as SettingsRow) || {};
 }
 
 export default function Chat() {
-  const [convId, setConvId] = useState<string | null>(null);
+  const [conv, setConv] = useState<Conversation | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [status, setStatus] = useState<string>('Ready');
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settings, setSettings] = useState<Partial<SettingsRow>>({});
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  /** Smooth scroll to bottom when messages change */
-  useEffect(() => {
-    queueMicrotask(() => {
-      try {
-        scrollRef.current?.scrollTo({ top: 1e9, behavior: 'smooth' });
-      } catch {
-        /* no-op */
-      }
-    });
-  }, [messages]);
+  useEffect(() => { queueMicrotask(() => scrollRef.current?.scrollTo({ top: 1e9 })); }, [messages]);
 
-  /** Initial load: make sure a conversation exists, then fetch messages */
   useEffect(() => {
     (async () => {
       setStatus('Ensuring conversation…');
-      const conv = await ensureConversation();
-      if (!conv) {
-        setStatus('Failed to create/load conversation (check console).');
-        return;
-      }
-      setConvId(conv.id);
+      const c = await ensureConversation();
+      if (!c) { setStatus('Failed to create/load conversation'); return; }
+      setConv(c);
       setStatus('Loading messages…');
-      const msgs = await fetchMessages(conv.id);
+      const msgs = await fetchMessages(c.id);
       setMessages(msgs);
+      setSettings(await loadSettings());
       setStatus('Ready');
-      log('Initial messages', msgs);
     })();
   }, []);
 
-  /** Full reload from DB */
   const reload = async () => {
-    if (!convId) return;
+    if (!conv) return;
     setStatus('Reloading…');
-    const msgs = await fetchMessages(convId);
-    setMessages(msgs);
+    const updated = await supabase.from('conversations').select('*').eq('id', conv.id).single();
+    if (!updated.error) setConv(updated.data as Conversation);
+    setMessages(await fetchMessages(conv.id));
+    setSettings(await loadSettings());
     setStatus('Ready');
   };
 
-  /** Sends a user message, calls assistant, updates DB + UI with strong logging */
-  const send = async (text: string) => {
-    if (!convId) {
-      alert('No conversation yet. Try refreshing.');
-      return;
-    }
-    const content = text.trim();
-    if (!content) return;
-
-    const userIdx = messages.length;
-    const userMsg: Message = {
-      conversation_id: convId,
-      role: 'user',
-      content,
-      idx: userIdx,
+  async function callAssistant(payloadMsgs: { role: string; content: string }[]) {
+    const body = {
+      messages: payloadMsgs,
+      model: settings.model || 'mistral-large-latest',
+      temperature: settings.temperature ?? 0.7,
+      max_tokens: settings.max_tokens ?? 2048,
+      safe_prompt: settings.safe_prompt ?? false
     };
+    log('callAssistant body', body);
+    const resp = await fetch('/api/chat', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
+    });
+    const text = await resp.text();
+    if (!resp.ok) { logError(`callAssistant HTTP ${resp.status}`, text); throw new Error(text.slice(0, 600)); }
+    const json = JSON.parse(text);
+    return json.content as string;
+  }
 
-    // 1) Optimistic UI
-    setMessages((prev) => prev.concat([{ ...userMsg } as any]));
-    setStatus('Sending…');
-    log('send: optimistic append (user)', userMsg);
+  /** If too long, summarize the older part and store in running_summary. */
+  const maybeSummarize = async () => {
+    if (!conv) return;
+    if (messages.length <= SUMMARIZE_AFTER) return;
 
-    // 2) Persist user message (fire-and-forget)
-    try {
-      const { error } = await supabase.from('messages').insert(userMsg);
-      if (error) logError('send: insert user failed', error);
-    } catch (e) {
-      logError('send: insert user threw', e);
+    setStatus('Summarizing older turns…');
+
+    // Keep system (idx 0) + last KEEP_RECENT turns; summarize the middle chunk
+    const keepHead = 1;
+    const cutStart = keepHead;
+    const cutEnd = Math.max(messages.length - KEEP_RECENT, keepHead);
+    const middle = messages.slice(cutStart, cutEnd);
+    if (middle.length === 0) { setStatus('Ready'); return; }
+
+    const transcript = middle.map(m => `[${m.role.toUpperCase()}] ${m.content}`).join('\n\n');
+
+    // Call summarize function
+    const resp = await fetch('/.netlify/functions/summarize', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ transcript })
+    });
+    const txt = await resp.text();
+    if (!resp.ok) { logError('summarize failed', txt); setStatus('Ready'); return; }
+    const { summary } = JSON.parse(txt);
+
+    // Save to conversations.running_summary (append)
+    const running = (conv.running_summary || '').trim();
+    const newSummary = running ? `${running}\n\n${summary}` : summary;
+    await supabase.from('conversations').update({ running_summary: newSummary }).eq('id', conv.id);
+
+    // Delete middle rows and re-index everything
+    for (const m of middle) await supabase.from('messages').delete().eq('id', m.id as string);
+    const fresh = await fetchMessages(conv.id);
+    for (let j = 0; j < fresh.length; j++) {
+      if (fresh[j].idx !== j) await supabase.from('messages').update({ idx: j }).eq('id', fresh[j].id as string);
     }
 
-    // 3) Build assistant payload and call server
-    try {
-      const payload = messages
-        .concat([{ role: 'user', content, idx: userIdx } as any])
-        .map((m) => ({ role: m.role, content: m.content }));
+    await reload();
+  };
 
-      const { content: assistantText } = await callAssistant(payload);
+  const send = async (text: string) => {
+    if (!conv) { alert('No conversation yet.'); return; }
+    const content = text.trim(); if (!content) return;
+    const userIdx = messages.length;
+
+    const userMsg: Message = { conversation_id: conv.id, role: 'user', content, idx: userIdx };
+    setMessages(prev => prev.concat([{ ...userMsg } as any]));
+    setStatus('Sending…');
+
+    // persist user
+    supabase.from('messages').insert(userMsg).then(({ error }) => error && logError('insert user', error));
+
+    // build payload with optional running summary prepended as a system hint
+    const base = messages.concat([{ role: 'user', content, idx: userIdx } as any])
+      .map(m => ({ role: m.role, content: m.content }));
+
+    const payload = conv.running_summary
+      ? [{ role: 'system', content: `Conversation so far (summary):\n${conv.running_summary}` }, ...base]
+      : base;
+
+    try {
+      const assistantText = await callAssistant(payload);
 
       const assistantMsg: Message = {
-        conversation_id: convId,
-        role: 'assistant',
-        content: assistantText || '(no content)',
-        idx: userIdx + 1,
+        conversation_id: conv.id, role: 'assistant', content: assistantText || '(no content)', idx: userIdx + 1
       };
-
-      // 4) Optimistic append assistant + persist
-      setMessages((prev) => prev.concat([{ ...assistantMsg } as any]));
-      log('send: optimistic append (assistant)', assistantMsg);
-
-      const { error: insErr } = await supabase.from('messages').insert(assistantMsg);
-      if (insErr) logError('send: insert assistant failed', insErr);
-
+      setMessages(prev => prev.concat([{ ...assistantMsg } as any]));
+      const { error: e2 } = await supabase.from('messages').insert(assistantMsg);
+      if (e2) logError('insert assistant', e2);
       setStatus('Ready');
+
+      // maybe summarize when it grows
+      await maybeSummarize();
     } catch (e: any) {
-      logError('send: callAssistant failed', e);
-      setStatus('Assistant call failed (see console).');
+      logError('send callAssistant', e);
+      setStatus('Assistant call failed');
       alert(`Assistant error:\n${String(e).slice(0, 600)}`);
-      // Keep UI consistent with DB
       await reload();
     }
   };
 
-  /** Save an inline edit (no model call) */
   const saveEdit = async (i: number, text: string) => {
-    const m = messages[i];
-    if (!m) return;
-    if (!m.id) {
-      // If no id (optimistic-only), reload to sync and get IDs, then try again
-      await reload();
-      const mm = messages[i];
-      if (!mm?.id) {
-        alert('Could not edit yet—try again after a second.');
-        return;
-      }
-    }
-
-    const newText = text ?? '';
+    const m = messages[i]; if (!m) return;
+    if (!m.id) { await reload(); if (!messages[i]?.id) { alert('Could not edit yet—try again after a second.'); return; } }
     setStatus('Saving edit…');
-    log('saveEdit: updating row', { id: m.id, i, role: m.role });
-
     try {
-      const { error } = await supabase.from('messages').update({ content: newText }).eq('id', m.id as string);
-      if (error) {
-        logError('saveEdit: update failed', error);
-        alert(`Edit failed: ${error.message ?? error}`);
-      } else {
-        setMessages((prev) => {
-          const copy = prev.slice();
-          copy[i] = { ...copy[i], content: newText };
-          return copy;
-        });
-      }
-    } catch (e) {
-      logError('saveEdit: update threw', e);
-      alert(`Edit error: ${String(e).slice(0, 400)}`);
-    } finally {
-      setStatus('Ready');
-    }
+      const { error } = await supabase.from('messages').update({ content: text ?? '' }).eq('id', m.id as string);
+      if (error) { logError('saveEdit', error); alert(`Edit failed: ${error.message ?? error}`); }
+      else setMessages(prev => { const c = prev.slice(); c[i] = { ...c[i], content: text ?? '' }; return c; });
+    } finally { setStatus('Ready'); }
   };
 
-  /** Delete a message and re-pack idx to keep a clean sequence */
   const deleteMsg = async (i: number) => {
-    const m = messages[i];
-    if (!m) return;
-    if (i === 0) {
-      alert('The system message cannot be deleted.');
-      return;
-    }
-    if (!m.id) {
-      await reload();
-    }
-
+    const m = messages[i]; if (!m) return;
+    if (i === 0) { alert('Cannot delete the system message.'); return; }
     setStatus('Deleting…');
-    log('deleteMsg: deleting row', { id: m.id, i, role: m.role });
-
     try {
-      const { error: delErr } = await supabase.from('messages').delete().eq('id', m.id as string);
-      if (delErr) {
-        logError('deleteMsg: delete failed', delErr);
-        alert(`Delete failed: ${delErr.message ?? delErr}`);
-        setStatus('Ready');
-        return;
-      }
-
-      // Re-fetch and re-index to avoid gaps
-      const list = await fetchMessages(convId!);
-      for (let j = 0; j < list.length; j++) {
-        const row = list[j];
-        if (row.idx !== j) {
-          const { error: updErr } = await supabase.from('messages').update({ idx: j }).eq('id', row.id as string);
-          if (updErr) logError('deleteMsg: reindex failed', updErr);
-        }
+      if (!m.id) await reload();
+      const { error } = await supabase.from('messages').delete().eq('id', m.id as string);
+      if (error) { logError('delete', error); alert(`Delete failed: ${error.message ?? error}`); }
+      // reindex
+      const fresh = await fetchMessages(conv!.id);
+      for (let j = 0; j < fresh.length; j++) {
+        if (fresh[j].idx !== j) await supabase.from('messages').update({ idx: j }).eq('id', fresh[j].id as string);
       }
       await reload();
-    } catch (e) {
-      logError('deleteMsg: threw', e);
-      alert(`Delete error: ${String(e).slice(0, 400)}`);
-    } finally {
-      setStatus('Ready');
-    }
+    } finally { setStatus('Ready'); }
   };
 
-  /** Regenerate from the selected turn */
   const regenFrom = async (i: number) => {
-    if (!convId) return;
-    const target = messages[i];
-    if (!target) return;
+    if (!conv) return;
+    const target = messages[i]; if (!target) return;
 
-    const cutAt = target.role === 'assistant' ? i - 1 : i; // keep up to user message
-    if (cutAt < 0) {
-      alert('Cannot regenerate before the first user turn.');
-      return;
-    }
+    const cutAt = target.role === 'assistant' ? i - 1 : i;
+    if (cutAt < 0) { alert('Cannot regenerate before first user turn.'); return; }
 
     setStatus('Regenerating…');
-    log('regenFrom: cutting at index', { i, cutAt, targetRole: target.role });
+    // delete tail
+    for (const t of messages.slice(cutAt + 1)) { if (t.id) await supabase.from('messages').delete().eq('id', t.id as string); }
+
+    const kept = messages.slice(0, cutAt + 1).map(m => ({ role: m.role, content: m.content }));
+    const payload = conv.running_summary
+      ? [{ role: 'system', content: `Conversation so far (summary):\n${conv.running_summary}` }, ...kept]
+      : kept;
 
     try {
-      // Delete tail (everything after cutAt)
-      const tail = messages.slice(cutAt + 1);
-      for (const t of tail) {
-        if (t.id) {
-          const { error: delErr } = await supabase.from('messages').delete().eq('id', t.id as string);
-          if (delErr) logError('regenFrom: delete tail failed', delErr);
-        }
-      }
-
-      // Build payload from kept messages
-      const kept = messages.slice(0, cutAt + 1).map((m) => ({ role: m.role, content: m.content }));
-      const { content } = await callAssistant(kept);
-
-      const newAssistant: Message = {
-        conversation_id: convId,
-        role: 'assistant',
-        content: content || '(no content)',
-        idx: cutAt + 1,
-      };
-
-      // Optimistic append + persist
-      setMessages((prev) => prev.slice(0, cutAt + 1).concat([{ ...newAssistant } as any]));
-      const { error: insErr } = await supabase.from('messages').insert(newAssistant);
-      if (insErr) logError('regenFrom: insert new assistant failed', insErr);
-
-      setStatus('Ready');
+      const content = await callAssistant(payload);
+      const newAssistant: Message = { conversation_id: conv.id, role: 'assistant', content: content || '(no content)', idx: cutAt + 1 };
+      setMessages(prev => prev.slice(0, cutAt + 1).concat([{ ...newAssistant } as any]));
+      await supabase.from('messages').insert(newAssistant);
     } catch (e) {
-      logError('regenFrom: failed', e);
+      logError('regenFrom', e);
       alert(`Regen error: ${String(e).slice(0, 600)}`);
+    } finally {
       await reload();
       setStatus('Ready');
     }
@@ -350,8 +244,14 @@ export default function Chat() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Tiny status/debug bar (stays readable on mobile) */}
-      <div className="sticky top-0 z-10 bg-amber-50 text-amber-800 border-b border-amber-200 px-3 py-1 text-xs">
+      <div className="sticky top-0 bg-white border-b px-4 py-2 flex items-center justify-between">
+        <span className="font-semibold">Chat</span>
+        <div className="flex items-center gap-2">
+          <button className="px-3 py-1 rounded border" onClick={() => setSettingsOpen(true)}>Settings</button>
+        </div>
+      </div>
+
+      <div className="sticky top-[41px] z-10 bg-amber-50 text-amber-800 border-b border-amber-200 px-3 py-1 text-xs">
         {status}
       </div>
 
@@ -369,6 +269,13 @@ export default function Chat() {
       </div>
 
       <Composer onSend={send} />
+
+      <Settings
+        conversationId={conv?.id ?? null}
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        onChanged={reload}
+      />
     </div>
   );
 }

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -1,28 +1,53 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { Message } from '../lib/types';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+marked.setOptions({
+  breaks: true,
+  gfm: true
+});
+
+function renderMarkdown(md: string) {
+  const html = marked.parse(md || '');
+  const clean = DOMPurify.sanitize(html as string);
+  return { __html: clean };
+}
 
 export default function MessageItem({
   m, i, onSave, onDelete, onRegen,
-}: { m: Message; i: number; onSave: (i: number, text: string) => void; onDelete: () => void; onRegen: () => void; }) {
+}: {
+  m: Message;
+  i: number;
+  onSave: (i: number, text: string) => void;
+  onDelete: () => void;
+  onRegen: () => void;
+}) {
   const [editing, setEditing] = useState(false);
   const [val, setVal] = useState(m.content);
   const isSystem = m.role === 'system';
   const bubble = m.role === 'user' ? 'bg-blue-100' : m.role === 'assistant' ? 'bg-zinc-200' : 'bg-white border border-dashed';
 
+  const md = useMemo(() => (m.role === 'assistant' ? renderMarkdown(m.content) : null), [m.content, m.role]);
+
   return (
     <div className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
       <div className={`max-w-[92%] rounded-2xl px-3 py-2 ${bubble}`}>
         <div className="text-xs text-zinc-500 mb-1">[{i}] {m.role[0].toUpperCase()}</div>
+
         {!editing ? (
-          <div className="whitespace-pre-wrap">{m.content}</div>
+          m.role === 'assistant'
+            ? <div className="prose prose-zinc max-w-none prose-pre:whitespace-pre-wrap" dangerouslySetInnerHTML={md!} />
+            : <div className="whitespace-pre-wrap">{m.content}</div>
         ) : (
           <textarea
             className="w-full p-2 border rounded bg-white"
-            rows={Math.min(10, Math.max(3, Math.ceil(val.length / 60)))}
+            rows={Math.min(12, Math.max(3, Math.ceil(val.length / 60)))}
             value={val}
             onChange={(e) => setVal(e.target.value)}
           />
         )}
+
         <div className="mt-2 space-x-2 text-sm">
           {!isSystem && !editing && (
             <>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import type { SettingsRow, Message } from '../lib/types';
+
+const MODELS = [
+  { id: 'mistral-large-latest', name: 'Mistral Large' },
+  { id: 'mistral-8b-latest', name: 'Mistral 8B' },
+  { id: 'mistral-3b-latest', name: 'Mistral 3B' },
+  { id: 'codestral-latest', name: 'Codestral (code)' },
+  { id: 'pixtral-12b-2409', name: 'Pixtral 12B' }
+];
+
+export default function Settings({
+  conversationId,
+  isOpen,
+  onClose,
+  onChanged
+}: {
+  conversationId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onChanged: () => void; // signal settings or system prompt changed
+}) {
+  const [row, setRow] = useState<Partial<SettingsRow>>({
+    model: 'mistral-large-latest',
+    temperature: 0.7,
+    max_tokens: 2048,
+    safe_prompt: false
+  });
+
+  const [systemPrompt, setSystemPrompt] = useState<string>('');
+
+  useEffect(() => {
+    (async () => {
+      const { data: auth } = await supabase.auth.getUser();
+      if (!auth?.user) return;
+      const { data } = await supabase.from('settings').select('*').eq('user_id', auth.user.id).maybeSingle();
+      if (data) setRow(data as SettingsRow);
+
+      // load system prompt (message idx 0)
+      if (conversationId) {
+        const { data: msgs } = await supabase
+          .from('messages')
+          .select('*')
+          .eq('conversation_id', conversationId)
+          .order('idx')
+          .limit(1);
+        const sys = (msgs?.[0] as Message | undefined);
+        setSystemPrompt(sys?.content || 'You are a helpful assistant.');
+      }
+    })();
+  }, [conversationId, isOpen]);
+
+  const saveSettings = async () => {
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth?.user) return;
+    const payload = {
+      user_id: auth.user.id,
+      model: row.model || 'mistral-large-latest',
+      temperature: Number(row.temperature ?? 0.7),
+      max_tokens: Number(row.max_tokens ?? 2048),
+      safe_prompt: Boolean(row.safe_prompt)
+    };
+    await supabase.from('settings').upsert(payload);
+    onChanged();
+  };
+
+  const saveSystemPrompt = async () => {
+    if (!conversationId) return;
+    // Update message idx 0 (system)
+    const { data: sysMsg } = await supabase
+      .from('messages')
+      .select('*')
+      .eq('conversation_id', conversationId)
+      .eq('idx', 0)
+      .limit(1);
+    const m = sysMsg?.[0] as Message | undefined;
+    if (!m) return;
+    await supabase.from('messages').update({ content: systemPrompt }).eq('id', m.id as string);
+    onChanged();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40">
+      <div className="absolute right-0 top-0 h-full w-full max-w-[520px] bg-white shadow-xl flex flex-col">
+        <div className="px-4 py-3 border-b flex items-center justify-between">
+          <div className="font-semibold">Settings</div>
+          <button className="px-3 py-1 rounded border" onClick={onClose}>Close</button>
+        </div>
+
+        <div className="p-4 space-y-6 overflow-auto">
+          <section>
+            <div className="font-medium mb-2">Model</div>
+            <select
+              className="w-full border rounded p-2"
+              value={row.model}
+              onChange={(e) => setRow((r) => ({ ...r, model: e.target.value }))}
+            >
+              {MODELS.map(m => <option key={m.id} value={m.id}>{m.name} ({m.id})</option>)}
+            </select>
+          </section>
+
+          <section className="grid grid-cols-2 gap-4">
+            <div>
+              <div className="font-medium mb-2">Temperature</div>
+              <input
+                type="number" step="0.1" min="0" max="2"
+                className="w-full border rounded p-2"
+                value={row.temperature ?? 0.7}
+                onChange={(e) => setRow((r) => ({ ...r, temperature: Number(e.target.value) }))}
+              />
+            </div>
+            <div>
+              <div className="font-medium mb-2">Max tokens</div>
+              <input
+                type="number" min="1" max="8192"
+                className="w-full border rounded p-2"
+                value={row.max_tokens ?? 2048}
+                onChange={(e) => setRow((r) => ({ ...r, max_tokens: Number(e.target.value) }))}
+              />
+            </div>
+          </section>
+
+          <section>
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={!!row.safe_prompt}
+                onChange={(e) => setRow((r) => ({ ...r, safe_prompt: e.target.checked }))}
+              />
+              <span>safe_prompt</span>
+            </label>
+          </section>
+
+          <div className="flex gap-2">
+            <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={saveSettings}>Save Settings</button>
+            <button className="px-3 py-2 rounded border" onClick={onClose}>Close</button>
+          </div>
+
+          <hr className="my-2" />
+
+          <section>
+            <div className="font-medium mb-2">System prompt</div>
+            <textarea
+              className="w-full border rounded p-2"
+              rows={10}
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+            />
+            <div className="mt-2">
+              <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={saveSystemPrompt}>Save System Prompt</button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,4 +15,14 @@ export interface Conversation {
   title: string;
   created_at: string;
   updated_at: string;
+  running_summary?: string;
+}
+
+export interface SettingsRow {
+  user_id: string;
+  model: string;
+  temperature: number;
+  max_tokens: number;
+  safe_prompt: boolean;
+  updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- render assistant replies as sanitized Markdown
- add user-configurable model settings and editable system prompt
- auto-summarize long conversations and track running summary

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05c3b6520832582701210010d0051